### PR TITLE
Use header_compile_args rather than duplicating cc_compile_args.

### DIFF
--- a/repobuild/nodes/cc_library.cc
+++ b/repobuild/nodes/cc_library.cc
@@ -98,7 +98,7 @@ void CCLibraryNode::Set(const vector<Resource>& sources,
   headers_ = headers;
   objects_ = objects;
   cc_compile_args_ = cc_compile_args;
-  header_compile_args_ = cc_compile_args;
+  header_compile_args_ = header_compile_args;
   Init();
 }
 


### PR DESCRIPTION
It compiles and runs to produce the same Makefile for repobuild itself.  I didn't run any other tests (would have to figure out additional apt-get installs).
